### PR TITLE
testing euler equation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,11 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[targets]
+test = ["Test", "TestItemRunner"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,5 @@
-using Test
-using SSJ
 
-@testset "SSJ.jl tests" begin
-    @test 1 == 1
 
-    @testset "all run" begin
-        # not a real test, but breaks if breaks.
-        main();
-        mainKS();
-        mainSSJ();
-    end
-end
+using TestItemRunner
+
+@run_package_tests

--- a/test/test_aiyagari.jl
+++ b/test/test_aiyagari.jl
@@ -1,0 +1,53 @@
+
+@testitem "Euler Error" begin
+
+    # defining the parameters of the model
+    rho = 0.966
+    s = 0.5
+    sig = s * sqrt(1 - rho^2)
+    params = SSJ.Params(0.96, 1.0, sig, rho, 0.025, 0.11, 0.0001, [0.0, 200.0], 200, 7, 300)
+
+    # set an r
+    r = 0.05
+    
+    # Setting up the model
+    BaseModel = SSJ.setup_Aiyagari(params)
+
+    agg_labor = SSJ.aggregate_labor(BaseModel.Π, BaseModel.shockgrid)
+    aggregates, prices = SSJ.get_AggsPrices(r, agg_labor, BaseModel)
+    policies = SSJ.EGM(BaseModel, prices)
+
+    # now test that `policies` are consistent
+
+	μ = zeros(params.n_a)  # vector of marginal utilities
+	iuprime = zeros(params.n_a,params.n_e)  # matrix of inverse marginal utilities
+	
+    # basically does `consumptiongrid`
+	for ie in 1:params.n_e
+		fill!(μ , 0.0)
+		for je in 1:params.n_e
+			pr = BaseModel.Π[ie,je]  # transprob
+
+			# get next period consumption if state is je
+            # cprime = (1+r) policygrid + w * shock[je] - policy[je]
+            # (params.n_a by 1)
+            cprimevec = ((1 + prices.r) * BaseModel.policygrid) .+ (prices.w .* BaseModel.shockgrid[je]) .- policies.saving[:,je]
+
+			# Expected marginal utility at each state of tomorrow's income shock
+    		global μ += pr * (cprimevec .^ ((-1) * params.γ))
+		end
+	   # RHS of euler equation
+    	rhs = params.β * (1 + prices.r) * μ
+		# today's consumption: inverse marginal utility over RHS
+    	iuprime[:,ie] = rhs .^ ((-1)/params.γ)
+	end
+    # println([iuprime  (policies.consumption)])
+
+    implied = ((1 + prices.r) * BaseModel.policymat) .+ (prices.w .* BaseModel.shockmat) .- policies.saving
+
+    # checks last penultimate line in `EGM`:
+    @test all(implied .== policies.consumption)
+
+    # checks reverse engineering of `consumptiongrid`
+	@test maximum(abs,(iuprime ./ policies.consumption) .- 1) < 0.0001
+end

--- a/test/test_aiyagari.jl
+++ b/test/test_aiyagari.jl
@@ -8,7 +8,7 @@
     params = SSJ.Params(0.96, 1.0, sig, rho, 0.025, 0.11, 0.0001, [0.0, 200.0], 200, 7, 300)
 
     # set an r
-    r = 0.05
+    r = 0.04
     
     # Setting up the model
     BaseModel = SSJ.setup_Aiyagari(params)
@@ -41,13 +41,10 @@
 		# today's consumption: inverse marginal utility over RHS
     	iuprime[:,ie] = rhs .^ ((-1)/params.γ)
 	end
-    # println([iuprime  (policies.consumption)])
 
-    implied = ((1 + prices.r) * BaseModel.policymat) .+ (prices.w .* BaseModel.shockmat) .- policies.saving
-
-    # checks last penultimate line in `EGM`:
-    @test all(implied .== policies.consumption)
+    savings = SSJ.policyupdate(prices,BaseModel.policymat,BaseModel.shockmat,iuprime)
+    cons = ((1 + prices.r) * BaseModel.policymat) + (prices.w * BaseModel.shockmat) - savings
 
     # checks reverse engineering of `consumptiongrid`
-	@test maximum(abs,(iuprime ./ policies.consumption) .- 1) < 0.0001
+	@test maximum(abs,(cons ./ policies.consumption) .- 1) < 0.00001
 end


### PR DESCRIPTION
I added a unit test for the euler equation. reverse-engineering your EGM step should yield the exact solution that is returned from `EGM`. At the moment there is something wrong. I've looked for a long time and could not find the problem, it seems I'm going just back step by step on what you did but there is an error remaining. can't exclude I made a mistake of course. you can run the test in VScode by clicking on the "testing" symbol (lab flask) in the left hand menu bar. or 

```
] test
```

but the VSCode way is super quick, so preferrable. 

Now to the test itself. I'm basically confused about how you apply EGM. I'm not sure which is the _endogenous_ part. I tend to think of it that here we choose the x-axis of the policy funciton, keeping the y-axis fixed (the end-of-period state). I am unsure which of those plots is the correct one:


```julia
julia> plot(BaseModel.policymat, policies.consumption)
```

<img width="620" alt="Screenshot 2024-07-16 at 18 04 56" src="https://github.com/user-attachments/assets/dd5e2022-096b-41d3-ad65-e708bc559487">



or 



```julia
julia> plot(policies.saving, policies.consumption)
```

<img width="620" alt="Screenshot 2024-07-16 at 18 04 31" src="https://github.com/user-attachments/assets/c17d55e2-39f4-49f2-af09-c57f7345a69d">

They are not identical.

Also: why this upward tick in the end in consumption? I would have said it should be close to linear at the upper end, but maybe there is a certain parameter that's causing this.
