### PR TITLE
identical KS solution to paper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,17 @@ version = "0.1.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,11 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[targets]
+test = ["Test", "TestItemRunner"]

--- a/src/GeneralStructures.jl
+++ b/src/GeneralStructures.jl
@@ -11,7 +11,7 @@ multiple dispatch to write more efficient code.
 """
 Params struct: contains the parameters of the model.
 """
-struct Params{TF<:Float64, TI<:Int64}
+mutable struct Params{TF<:Float64, TI<:Int64}
     β::TF # discount factor
     γ::TF # coefficient of relative risk aversion
     σ::TF # standard deviation of the shock process
@@ -23,6 +23,7 @@ struct Params{TF<:Float64, TI<:Int64}
     n_a::TI # number of grid points for the savings grid
     n_e::TI # number of grid points for the shock grid
     T::TI # number of periods for the transition path
+    Z::TF # TFP
 end
 
 
@@ -30,9 +31,9 @@ end
 Prices struct: contains the two main prices of the model,
 the interest rate and the wage rate.
 """
-struct Prices{TF<:Float64}
-    r::TF
-    w::TF
+struct Prices
+    r
+    w
 end
 
 
@@ -43,6 +44,16 @@ supply in the economy.
 struct Aggregates{TF<:Float64}
     agg_ks::TF
     agg_labor::TF
+end
+
+"""
+Aggregates struct: contains the aggregate capital and labor
+supply, and output in the economy.
+"""
+struct Aggregates2
+    agg_ks
+    agg_labor
+    Y
 end
 
 
@@ -74,6 +85,14 @@ struct SteadyState{TF<:Float64}
     policies::NamedTuple{(:saving, :consumption), Tuple{Matrix{TF}, Matrix{TF}}} # savings and consumption policies
     D::Vector{TF} # steady state distribution of wealth
     aggregates::Aggregates # steady state aggregate capital and labor
+    Λ::SparseMatrixCSC{TF,Int64} # steady state transition matrix for the distribution of wealth
+end
+
+struct SteadyState2{TF<:Float64}
+    prices::Prices # steady state prices
+    policies::NamedTuple{(:saving, :consumption), Tuple{Matrix{TF}, Matrix{TF}}} # savings and consumption policies
+    D::Vector{TF} # steady state distribution of wealth
+    aggregates::Aggregates2 # steady state aggregate capital and labor
     Λ::SparseMatrixCSC{TF,Int64} # steady state transition matrix for the distribution of wealth
 end
 

--- a/src/HelperFunctions.jl
+++ b/src/HelperFunctions.jl
@@ -160,7 +160,7 @@ function invariant_dist(Π::AbstractMatrix;
     method::Int64 = 1,
     ε::Float64 = 1e-9,
     itermax::Int64 = 50000,
-    initVector::Union{Nothing, Vector{Float64}}=nothing,
+    initVector=nothing,
     verbose::Bool = false
     )
 

--- a/src/SSJ.jl
+++ b/src/SSJ.jl
@@ -3,6 +3,11 @@ module SSJ
 greet() = print("Hello World!")
 
 using LinearAlgebra, Plots, Distributions, SparseArrays, UnPack, Roots
+using NLsolve
+using Infiltrator
+# using OptimizationPRIMA, Optimization
+# using NonlinearSolve
+# using SteadyStateDiffEq
 
 import IterativeSolvers, Interpolations
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,5 @@
-using Test
-using SSJ
 
-@testset "SSJ.jl tests" begin
-    @test 1 == 1
 
-    @testset "all run" begin
-        # not a real test, but breaks if breaks.
-        main();
-        mainKS();
-        mainSSJ();
-    end
-end
+using TestItemRunner
+
+@run_package_tests

--- a/test/test_aiyagari.jl
+++ b/test/test_aiyagari.jl
@@ -1,0 +1,53 @@
+
+@testitem "Euler Error" begin
+
+    # defining the parameters of the model
+    rho = 0.966
+    s = 0.5
+    sig = s * sqrt(1 - rho^2)
+    params = SSJ.Params(0.96, 1.0, sig, rho, 0.025, 0.11, 0.0001, [0.0, 200.0], 200, 7, 300)
+
+    # set an r
+    r = 0.05
+    
+    # Setting up the model
+    BaseModel = SSJ.setup_Aiyagari(params)
+
+    agg_labor = SSJ.aggregate_labor(BaseModel.Π, BaseModel.shockgrid)
+    aggregates, prices = SSJ.get_AggsPrices(r, agg_labor, BaseModel)
+    policies = SSJ.EGM(BaseModel, prices)
+
+    # now test that `policies` are consistent
+
+	μ = zeros(params.n_a)  # vector of marginal utilities
+	iuprime = zeros(params.n_a,params.n_e)  # matrix of inverse marginal utilities
+	
+    # basically does `consumptiongrid`
+	for ie in 1:params.n_e
+		fill!(μ , 0.0)
+		for je in 1:params.n_e
+			pr = BaseModel.Π[ie,je]  # transprob
+
+			# get next period consumption if state is je
+            # cprime = (1+r) policygrid + w * shock[je] - policy[je]
+            # (params.n_a by 1)
+            cprimevec = ((1 + prices.r) * BaseModel.policygrid) .+ (prices.w .* BaseModel.shockgrid[je]) .- policies.saving[:,je]
+
+			# Expected marginal utility at each state of tomorrow's income shock
+    		global μ += pr * (cprimevec .^ ((-1) * params.γ))
+		end
+	   # RHS of euler equation
+    	rhs = params.β * (1 + prices.r) * μ
+		# today's consumption: inverse marginal utility over RHS
+    	iuprime[:,ie] = rhs .^ ((-1)/params.γ)
+	end
+    # println([iuprime  (policies.consumption)])
+
+    implied = ((1 + prices.r) * BaseModel.policymat) .+ (prices.w .* BaseModel.shockmat) .- policies.saving
+
+    # checks last penultimate line in `EGM`:
+    @test all(implied .== policies.consumption)
+
+    # checks reverse engineering of `consumptiongrid`
+	@test maximum(abs,(iuprime ./ policies.consumption) .- 1) < 0.0001
+end

--- a/test/test_aiyagari.jl
+++ b/test/test_aiyagari.jl
@@ -8,7 +8,7 @@
     params = SSJ.Params(0.96, 1.0, sig, rho, 0.025, 0.11, 0.0001, [0.0, 200.0], 200, 7, 300)
 
     # set an r
-    r = 0.05
+    r = 0.04
     
     # Setting up the model
     BaseModel = SSJ.setup_Aiyagari(params)
@@ -41,13 +41,10 @@
 		# today's consumption: inverse marginal utility over RHS
     	iuprime[:,ie] = rhs .^ ((-1)/params.γ)
 	end
-    # println([iuprime  (policies.consumption)])
 
-    implied = ((1 + prices.r) * BaseModel.policymat) .+ (prices.w .* BaseModel.shockmat) .- policies.saving
-
-    # checks last penultimate line in `EGM`:
-    @test all(implied .== policies.consumption)
+    savings = SSJ.policyupdate(prices,BaseModel.policymat,BaseModel.shockmat,iuprime)
+    cons = ((1 + prices.r) * BaseModel.policymat) + (prices.w * BaseModel.shockmat) - savings
 
     # checks reverse engineering of `consumptiongrid`
-	@test maximum(abs,(iuprime ./ policies.consumption) .- 1) < 0.0001
+	@test maximum(abs,(cons ./ policies.consumption) .- 1) < 0.00001
 end


### PR DESCRIPTION
My aim was to get a method that delivers numerically identical solutions to what is reported in the paper and in the their notebooks. When I say _they_ I mean of course [them](https://github.com/shade-econ/sequence-jacobian). I wanted to reproduce this result from their KS [notebook](https://github.com/floswald/sequence-jacobian/blob/master/notebooks/krusell_smith.ipynb):

<img width="1167" alt="Screenshot 2024-07-18 at 14 43 20" src="https://github.com/user-attachments/assets/dc62c5a6-284b-4305-8ec6-ded5b34d5c0e">

This required, as you said, to change the solution approach slightly; no longer _search_ for an `r` that clears the asset market, but specify a set of targets which the SS should achieve (`r = 0.01, Y =1, asset_mkt = 0`), while choosing 3 variables `beta, Z, K`. This leads to a few small modifications in your code. Let us call the approach `search_beta` approach.

## Identical solution?

I am using `nlsolve` to look for `beta, Z, K`. The obtained solution is numerically identical (except for beta which is slightly different, but acceptable) to what they get (notice `n_a = 500`):

```julia
julia> SSJ.main_r(0.01);
[ Info: beta = 0.9894626201799099
[ Info: K = 3.142857142857143
[ Info: Z = 0.8816460975214567
Steady state interest rate: 0.010000000000000002
Steady state wage rate: 0.8900000000000001
Steady state Z: 0.8816460975214567
Steady state β: 0.9894626201799099
Steady state aggregate capital: 3.620693240677122
Steady state aggregate labor: 1.0
Steady state aggregate output: 1.0
```

## Performance is poor

I found performance relative to their code to be really bad. Their steady state takes about 1 second to compute on my computer:

```python
%timeit ss = ks.solve_steady_state(calibration, unknowns_ss, targets_ss, solver='hybr')
1.09 s ± 614 μs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Whereas my implemention of `search_beta` takes 37 times longer.

```julia
@time SSJ.main_r(0.01);
 37.073224 seconds (35.15 M allocations: 57.352 GiB, 10.43% gc time, 0.24% compilation time)
```

I can change that a little bit by decreasing the tolerance on the `nlsolve` call but not really 37 times.

## Performance fairly poor on previous version

I timed your solution as well:

```julia
julia> @time SSJ.main();
 12.727960 seconds (13.57 M allocations: 19.042 GiB, 9.75% gc time)
```

so, despite only having to solve a univariate equation system, this takes 12 times longer than theirs, for the same grid sizes.

## performance improvements

I investigated a few things:

1. type instabilities: there was one instability which I removed; no big change. so that's not it.
2. allocations: we seem to do way too many allocations. 13m allocs in your version ( my version is roughly scaling your version by 3 because there are 3 dimensions to search over...). This concerns `EGM`, `consumptiongrid` etc, each of which re-allocate new matrices upon each call. We can clearly do better here by storing those matrices on the model object once and for all.
3. autodiff: I tried out a few different options for the nonlinear system solver. NonlinearSolve.jl looks promising but really relies on autodiff. So I went and tried to make the code usable, but there are so many type annotations which trip up the AD systems that this is never going to work. This branch has a few attempts at this, with extra types that do not type annotate, so that they could be used in an AD call; no success however.
4. linear interpolation. We spend almost 100% of the time in `linpolate.(policymat[:,i])`. In particular in `searchsortedlast`. that's the function that searches for which bracket `x` lies in `xvec`. given that our `xvec` is _always_ monotonically increasing, we can do much better here. if you found the bracket of `x[i]` is `j`, you know that the bracket of `x[i+1]` has to be greater or equal to `j`. 

Let me know if you have some bandwidth to investigate those performance implications or whether you are actually fine with the package as is, given you want to use if mainly for teaching purposes.
